### PR TITLE
Algorithms | Arrays - two sum

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -12,6 +12,8 @@
                   * [Majorityelement](https://github.com/BrianLusina/KotlinGround/blob/master/algorithms/src/main/kotlin/com/kotlinground/algorithms/arrays/majorityelement/majorityElement.kt)
                 * Removeelement
                   * [Removeelement](https://github.com/BrianLusina/KotlinGround/blob/master/algorithms/src/main/kotlin/com/kotlinground/algorithms/arrays/removeelement/removeelement.kt)
+                * Twosum
+                  * [Twosum](https://github.com/BrianLusina/KotlinGround/blob/master/algorithms/src/main/kotlin/com/kotlinground/algorithms/arrays/twosum/twoSum.kt)
               * Backtracking
                 * Decodemessage
                   * [Numberofwaystodecodemessage](https://github.com/BrianLusina/KotlinGround/blob/master/algorithms/src/main/kotlin/com/kotlinground/algorithms/backtracking/decodemessage/numberOfWaysToDecodeMessage.kt)
@@ -97,6 +99,8 @@
                   * [Majorityelementtest](https://github.com/BrianLusina/KotlinGround/blob/master/algorithms/src/test/kotlin/com/kotlinground/algorithms/arrays/majorityelement/MajorityElementTest.kt)
                 * Removeelement
                   * [Removeelementtest](https://github.com/BrianLusina/KotlinGround/blob/master/algorithms/src/test/kotlin/com/kotlinground/algorithms/arrays/removeelement/RemoveElementTest.kt)
+                * Twosum
+                  * [Twosumtest](https://github.com/BrianLusina/KotlinGround/blob/master/algorithms/src/test/kotlin/com/kotlinground/algorithms/arrays/twosum/TwoSumTest.kt)
               * Backtracking
                 * Decodemessage
                   * [Numberofwaystodecodemessagetest](https://github.com/BrianLusina/KotlinGround/blob/master/algorithms/src/test/kotlin/com/kotlinground/algorithms/backtracking/decodemessage/NumberOfWaysToDecodeMessageTest.kt)
@@ -493,6 +497,8 @@
                 * [Series](https://github.com/BrianLusina/KotlinGround/blob/master/ktmath/src/main/kotlin/com/kotlinground/ktmath/largestSeriesProduct/Series.kt)
               * Ntheven
                 * [Ntheven](https://github.com/BrianLusina/KotlinGround/blob/master/ktmath/src/main/kotlin/com/kotlinground/ktmath/ntheven/ntheven.kt)
+              * Pascalstriangle
+                * [Pascalstriangle](https://github.com/BrianLusina/KotlinGround/blob/master/ktmath/src/main/kotlin/com/kotlinground/ktmath/pascalstriangle/pascalsTriangle.kt)
               * Perfectnumbers
                 * [Naturalnumber](https://github.com/BrianLusina/KotlinGround/blob/master/ktmath/src/main/kotlin/com/kotlinground/ktmath/perfectNumbers/NaturalNumber.kt)
               * Powersofi
@@ -525,6 +531,8 @@
                 * [Squarestest](https://github.com/BrianLusina/KotlinGround/blob/master/ktmath/src/test/kotlin/com/kotlinground/ktmath/diffOfSquares/SquaresTest.kt)
               * Largestseriesproduct
                 * [Seriestest](https://github.com/BrianLusina/KotlinGround/blob/master/ktmath/src/test/kotlin/com/kotlinground/ktmath/largestSeriesProduct/SeriesTest.kt)
+              * Pascalstriangle
+                * [Pascalstriangletest](https://github.com/BrianLusina/KotlinGround/blob/master/ktmath/src/test/kotlin/com/kotlinground/ktmath/pascalstriangle/PascalsTriangleTest.kt)
               * Perfectnumbers
                 * [Naturalnumbertest](https://github.com/BrianLusina/KotlinGround/blob/master/ktmath/src/test/kotlin/com/kotlinground/ktmath/perfectNumbers/NaturalNumberTest.kt)
               * Primes
@@ -557,6 +565,8 @@
                 * [Findcapitals](https://github.com/BrianLusina/KotlinGround/blob/master/ktstrings/src/main/kotlin/com/kotlinground/strings/findcapitals/findCapitals.kt)
               * Firstandlast
                 * [Removechars](https://github.com/BrianLusina/KotlinGround/blob/master/ktstrings/src/main/kotlin/com/kotlinground/strings/firstandlast/removeChars.kt)
+              * Firstoccurrence
+                * [Strstr](https://github.com/BrianLusina/KotlinGround/blob/master/ktstrings/src/main/kotlin/com/kotlinground/strings/firstoccurrence/strStr.kt)
               * Gcdofstrings
                 * [Gcdofstrings](https://github.com/BrianLusina/KotlinGround/blob/master/ktstrings/src/main/kotlin/com/kotlinground/strings/gcdofstrings/gcdOfStrings.kt)
               * Highlows
@@ -590,6 +600,8 @@
                 * [Findcapitalstest](https://github.com/BrianLusina/KotlinGround/blob/master/ktstrings/src/test/kotlin/com/kotlinground/strings/findcapitals/FindCapitalsTest.kt)
               * Firstandlast
                 * [Removecharskttest](https://github.com/BrianLusina/KotlinGround/blob/master/ktstrings/src/test/kotlin/com/kotlinground/strings/firstandlast/RemoveCharsKtTest.kt)
+              * Firstoccurrence
+                * [Strstrtest](https://github.com/BrianLusina/KotlinGround/blob/master/ktstrings/src/test/kotlin/com/kotlinground/strings/firstoccurrence/StrStrTest.kt)
               * Gcdofstrings
                 * [Gcdofstringstest](https://github.com/BrianLusina/KotlinGround/blob/master/ktstrings/src/test/kotlin/com/kotlinground/strings/gcdofstrings/GcdOfStringsTest.kt)
               * Isomorphic
@@ -623,6 +635,8 @@
               * Arrays
                 * Array Three Pointers
                   * [Minimize](https://github.com/BrianLusina/KotlinGround/blob/master/puzzles/src/main/kotlin/com/kotlinground/puzzles/arrays/array_three_pointers/minimize.kt)
+                * Candy
+                  * [Candy](https://github.com/BrianLusina/KotlinGround/blob/master/puzzles/src/main/kotlin/com/kotlinground/puzzles/arrays/candy/candy.kt)
                 * Canplaceflowers
                   * [Canplaceflowers](https://github.com/BrianLusina/KotlinGround/blob/master/puzzles/src/main/kotlin/com/kotlinground/puzzles/arrays/canplaceflowers/canplaceflowers.kt)
                 * Containerwithmostwater
@@ -725,6 +739,8 @@
               * Arrays
                 * Array Three Pointers
                   * [Minimizetest](https://github.com/BrianLusina/KotlinGround/blob/master/puzzles/src/test/kotlin/com/kotlinground/puzzles/arrays/array_three_pointers/MinimizeTest.kt)
+                * Candy
+                  * [Candytest](https://github.com/BrianLusina/KotlinGround/blob/master/puzzles/src/test/kotlin/com/kotlinground/puzzles/arrays/candy/CandyTest.kt)
                 * Canplaceflowers
                   * [Canplaceflowerstest](https://github.com/BrianLusina/KotlinGround/blob/master/puzzles/src/test/kotlin/com/kotlinground/puzzles/arrays/canplaceflowers/CanplaceflowersTest.kt)
                 * Containerwithmostwater

--- a/algorithms/src/main/kotlin/com/kotlinground/algorithms/arrays/twosum/README.md
+++ b/algorithms/src/main/kotlin/com/kotlinground/algorithms/arrays/twosum/README.md
@@ -1,0 +1,42 @@
+# Two Sum - Input Array Is Sorted
+
+Given a 1-indexed array of integers numbers that is already sorted in non-decreasing order, find two numbers such that
+they add up to a specific target number. Let these two numbers be numbers[index1] and numbers[index2] where 1 <=
+index1 < index2 <= numbers.length.
+
+Return the indices of the two numbers, index1 and index2, added by one as an integer array [index1, index2] of length 2.
+
+The tests are generated such that there is exactly one solution. You may not use the same element twice.
+
+Your solution must use only constant extra space.
+
+```text
+
+Example 1:
+
+Input: numbers = [2,7,11,15], target = 9
+Output: [1,2]
+Explanation: The sum of 2 and 7 is 9. Therefore, index1 = 1, index2 = 2. We return [1, 2].
+```
+
+```text
+Example 2:
+
+Input: numbers = [2,3,4], target = 6
+Output: [1,3]
+Explanation: The sum of 2 and 4 is 6. Therefore index1 = 1, index2 = 3. We return [1, 3].
+```
+
+```text
+Example 3:
+
+Input: numbers = [-1,0], target = -1
+Output: [1,2]
+Explanation: The sum of -1 and 0 is -1. Therefore index1 = 1, index2 = 2. We return [1, 2].
+```
+
+## Related Topics
+
+- Array
+- Two Pointers
+- Binary Search

--- a/algorithms/src/main/kotlin/com/kotlinground/algorithms/arrays/twosum/twoSum.kt
+++ b/algorithms/src/main/kotlin/com/kotlinground/algorithms/arrays/twosum/twoSum.kt
@@ -1,0 +1,16 @@
+package com.kotlinground.algorithms.arrays.twosum
+
+fun twoSum(numbers: IntArray, target: Int): IntArray {
+    var left = 0
+    var right = numbers.size - 1
+
+    while (left < right) {
+        val sum = numbers[left] + numbers[right]
+        when {
+            sum > target -> right -= 1
+            sum < target -> left += 1
+            else -> return intArrayOf(left + 1, right + 1)
+        }
+    }
+    return intArrayOf()
+}

--- a/algorithms/src/test/kotlin/com/kotlinground/algorithms/arrays/twosum/TwoSumTest.kt
+++ b/algorithms/src/test/kotlin/com/kotlinground/algorithms/arrays/twosum/TwoSumTest.kt
@@ -1,0 +1,34 @@
+package com.kotlinground.algorithms.arrays.twosum
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+
+class TwoSumTest {
+
+    @Test
+    fun `numbers = (2,7,11,15), target = 9`() {
+        val numbers = intArrayOf(2, 7, 11, 15)
+        val target = 9
+        val expected = intArrayOf(1, 2)
+        val actual = twoSum(numbers, target)
+        assertContentEquals(expected, actual)
+    }
+
+    @Test
+    fun `numbers = (2,3,4), target = 6`() {
+        val numbers = intArrayOf(2,3,4)
+        val target = 6
+        val expected = intArrayOf(1, 3)
+        val actual = twoSum(numbers, target)
+        assertContentEquals(expected, actual)
+    }
+
+    @Test
+    fun `numbers = (-1,0), target = -1`() {
+        val numbers = intArrayOf(-1, 0)
+        val target = -1
+        val expected = intArrayOf(1, 2)
+        val actual = twoSum(numbers, target)
+        assertContentEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
### Two Sum

Given a 1-indexed array of integers numbers that is already sorted in non-decreasing order, find two numbers such that
they add up to a specific target number. Let these two numbers be numbers[index1] and numbers[index2] where 1 <=
index1 < index2 <= numbers.length.

* [x] Add an algorithm?

### **Checklist:**

* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Kotlin files are placed inside an existing directory.
* [x] All functions and variable names follow Kotlin naming conventions.
* [x] All functions have associated tests